### PR TITLE
[kube-prometheus-stack] Update Grafana chart version to 6.18.*

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 2.2.1
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.17.10
-digest: sha256:2bf445d1234aff03121fefeed00b5744edf51f89ba1deec176092b6ce5ede255
-generated: "2021-12-01T08:58:43.3466742Z"
+  version: 6.18.1
+digest: sha256:1cff0ef8b6f4955f9f71b608779e276441964ab7fd9f58eb587b97c40ac946da
+generated: "2021-12-06T10:57:00.41178+01:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -18,7 +18,7 @@ name: kube-prometheus-stack
 sources:
   - https://github.com/prometheus-community/helm-charts
   - https://github.com/prometheus-operator/kube-prometheus
-version: 21.0.4
+version: 21.1.0
 appVersion: 0.52.0
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/prometheus-operator/kube-prometheus
@@ -44,6 +44,6 @@ dependencies:
   repository: https://prometheus-community.github.io/helm-charts
   condition: nodeExporter.enabled
 - name: grafana
-  version: "6.17.*"
+  version: "6.18.*"
   repository: https://grafana.github.io/helm-charts
   condition: grafana.enabled


### PR DESCRIPTION
Update Grafana helm chart to 6.18.* which updates Grafana to 8.3.0
